### PR TITLE
Changed style property for dot's color

### DIFF
--- a/src/components/elements/Scheduler.jsx
+++ b/src/components/elements/Scheduler.jsx
@@ -115,8 +115,9 @@ class Scheduler extends Component {
                     >
                         <div
                             className={
-                                `scheduler-table-body-event clickable scheduler-table-${events.am.color}`
+                                `scheduler-table-body-event clickable scheduler-table`
                             }
+                            style={{backgroundImage: `linear-gradient(to right, ${events.am.color},${events.am.color})`}}
                             data-dayoffid={
                                 events.am.dayoffId
                             }


### PR DESCRIPTION
On page print, background-color property is not used by default so I had to change the way to apply color to dots 

<img width="1347" height="859" alt="image" src="https://github.com/user-attachments/assets/13784e16-fc37-48b9-a941-785d239da79c" />
