### PR TITLE
Fix/issue#21:color-dots-on-page-print

### DIFF
--- a/src/css/elements/scheduler.css
+++ b/src/css/elements/scheduler.css
@@ -1,6 +1,7 @@
 .scheduler {
     /* padding: 0 20px; */
     text-align: center;
+    print-color-adjust: exact;  
 }
 
 .scheduler-table {


### PR DESCRIPTION
On page print, background-color property is not used by default, print-color-adjust allows to enable it